### PR TITLE
Made iText generated pdfs parsable

### DIFF
--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -402,7 +402,7 @@ class tcpdi_parser {
         unset($matches);
         $xref['max_object'] = max($xref['max_object'], $obj_num);
         // get trailer data
-        if (preg_match('/trailer[\s]*<<(.*)>>[\s]*[\r\n]+startxref[\s]*[\r\n]+/isU', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE, $xoffset) > 0) {
+        if (preg_match('/trailer[\s]*<<(.*)>>[\s]*[\r\n]+[^\r\n]*[\r\n]*startxref[\s]*[\r\n]+/isU', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE, $xoffset) > 0) {
             $trailer_data = $matches[1][0];
             if (!isset($xref['trailer']) OR empty($xref['trailer'])) {
                 // get only the last updated version


### PR DESCRIPTION
I have a PDF that has the following ending lines:
trailer
<</Size 132/Root 130 0 R/Info 131 0 R/ID [<b5bc655ffb0736452cc7cdb2e082d330><b5bc655ffb0736452cc7cdb2e082d330>]>>
%iText-5.5.6
startxref
3986146
%%EOF

As you can see there is an additional line %iText-5.5.6 which makes the parser return Unable to find trailer.
This patch will fix that.
