### PR TITLE
abandoned tecnick.com/tcpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-        "tecnick.com/tcpdf": "dev-master"
+        "tecnickcom/tcpdf": "dev-master"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
The package tecnick.com/tcpdf is abandoned and the new namespace tecnickcom/tcpdf should be used.

The packagist-namespace references to the same github-repository
