### PR TITLE
Fix Warning and Deprecated errors

### DIFF
--- a/tcpdi.php
+++ b/tcpdi.php
@@ -626,7 +626,7 @@ class TCPDI extends FPDF_TPL {
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
+                foreach ($value[1] as $k => $v) {
                     $this->_straightOut($k . ' ');
                     $this->pdf_write_value($v);
                 }

--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -480,7 +480,7 @@ class tcpdi_parser {
             $v = $sarr[$key];
             if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
+            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1]) >= 2)) {
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection


### PR DESCRIPTION
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in tcpdi_parser.php on line 483

PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in tcpdi.php on line 629