### PR TITLE
Fix for PHP 7.2+ count() error

### DIFF
--- a/tcpdi.php
+++ b/tcpdi.php
@@ -723,7 +723,7 @@ class TCPDI extends FPDF_TPL {
      * close all files opened by parsers
      */
     function _closeParsers() {
-        if ($this->state > 2 && count($this->parsers) > 0) {
+        if ($this->state > 2 && ($this->parsers) > 0) {
           	$this->cleanUp();
             return true;
         }


### PR DESCRIPTION
Fix for error - "count(): Parameter must be an array or an object that implements Countable". 
Error occurred when no PDFs were available for merging with the TCPDF generated Document.