### PR TITLE
Set fixed tcpdf major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-        "tecnickcom/tcpdf": "dev-master"
+        "tecnickcom/tcpdf": "^6.3"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
would be good IMHO because otherwise you need to set "minimum-stability" on every using project.