### PR TITLE
phpdoc typo fix

### DIFF
--- a/fpdf_tpl.php
+++ b/fpdf_tpl.php
@@ -189,7 +189,7 @@ class FPDF_TPL extends FPDF {
      * @param int $_y The y-position
      * @param int $_w The new width of the template
      * @param int $_h The new height of the template
-     * @retrun array The height and width of the template
+     * @return array The height and width of the template
      */
     function useTemplate($tplidx, $_x = null, $_y = null, $_w = 0, $_h = 0) {
         if ($this->page <= 0)


### PR DESCRIPTION
There is a typo in the phpdoc. This causes following error:

``` bash
In AnnotationException.php line 54:
                                                                                                                                                                        
[Semantical Error] The annotation "@retrun" in method FPDF_TPL::useTemplate() was never imported. Did you maybe forget to add a "use" statement for this annotation?
```