### PR TITLE
fix: format + syntax error

### DIFF
--- a/tcpdi.php
+++ b/tcpdi.php
@@ -283,7 +283,7 @@ class TCPDI extends FPDF_TPL {
 
         if (is_array($annots) && $annots[0] == PDF_TYPE_OBJECT // We got an object
                 && is_array($annots[1]) && $annots[1][0] == PDF_TYPE_ARRAY // It's an array
-                && is_array($annots[1][1]) && count($annots[1][1] > 1) // It's not empty - there are annotations for this page
+                && is_array($annots[1][1]) && count($annots[1][1]) > 1 // It's not empty - there are annotations for this page
         ) {
             if (!isset($this->_obj_stack[$fn])) {
                 $this->_obj_stack[$fn] = array();

--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -47,32 +47,32 @@
  * @version 1.1
  */
 
-if (!defined ('PDF_TYPE_NULL'))
-    define ('PDF_TYPE_NULL', 0);
-if (!defined ('PDF_TYPE_NUMERIC'))
-    define ('PDF_TYPE_NUMERIC', 1);
-if (!defined ('PDF_TYPE_TOKEN'))
-    define ('PDF_TYPE_TOKEN', 2);
-if (!defined ('PDF_TYPE_HEX'))
-    define ('PDF_TYPE_HEX', 3);
-if (!defined ('PDF_TYPE_STRING'))
-    define ('PDF_TYPE_STRING', 4);
-if (!defined ('PDF_TYPE_DICTIONARY'))
-    define ('PDF_TYPE_DICTIONARY', 5);
-if (!defined ('PDF_TYPE_ARRAY'))
-    define ('PDF_TYPE_ARRAY', 6);
-if (!defined ('PDF_TYPE_OBJDEC'))
-    define ('PDF_TYPE_OBJDEC', 7);
-if (!defined ('PDF_TYPE_OBJREF'))
-    define ('PDF_TYPE_OBJREF', 8);
-if (!defined ('PDF_TYPE_OBJECT'))
-    define ('PDF_TYPE_OBJECT', 9);
-if (!defined ('PDF_TYPE_STREAM'))
-    define ('PDF_TYPE_STREAM', 10);
-if (!defined ('PDF_TYPE_BOOLEAN'))
-    define ('PDF_TYPE_BOOLEAN', 11);
-if (!defined ('PDF_TYPE_REAL'))
-    define ('PDF_TYPE_REAL', 12);
+if (!defined('PDF_TYPE_NULL'))
+    define('PDF_TYPE_NULL', 0);
+if (!defined('PDF_TYPE_NUMERIC'))
+    define('PDF_TYPE_NUMERIC', 1);
+if (!defined('PDF_TYPE_TOKEN'))
+    define('PDF_TYPE_TOKEN', 2);
+if (!defined('PDF_TYPE_HEX'))
+    define('PDF_TYPE_HEX', 3);
+if (!defined('PDF_TYPE_STRING'))
+    define('PDF_TYPE_STRING', 4);
+if (!defined('PDF_TYPE_DICTIONARY'))
+    define('PDF_TYPE_DICTIONARY', 5);
+if (!defined('PDF_TYPE_ARRAY'))
+    define('PDF_TYPE_ARRAY', 6);
+if (!defined('PDF_TYPE_OBJDEC'))
+    define('PDF_TYPE_OBJDEC', 7);
+if (!defined('PDF_TYPE_OBJREF'))
+    define('PDF_TYPE_OBJREF', 8);
+if (!defined('PDF_TYPE_OBJECT'))
+    define('PDF_TYPE_OBJECT', 9);
+if (!defined('PDF_TYPE_STREAM'))
+    define('PDF_TYPE_STREAM', 10);
+if (!defined('PDF_TYPE_BOOLEAN'))
+    define('PDF_TYPE_BOOLEAN', 11);
+if (!defined('PDF_TYPE_REAL'))
+    define('PDF_TYPE_REAL', 12);
 
 /**
  * @class tcpdi_parser
@@ -83,7 +83,8 @@ if (!defined ('PDF_TYPE_REAL'))
  * @author Paul Nicholls - github.com/pauln
  * @author Nicola Asuni - info@tecnick.com
  */
-class tcpdi_parser {
+class tcpdi_parser
+{
     /**
      * Unique parser ID
      * @public
@@ -169,7 +170,7 @@ class tcpdi_parser {
      */
     public $availableBoxes = array('/MediaBox', '/CropBox', '/BleedBox', '/TrimBox', '/ArtBox');
 
-// -----------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------
 
     /**
      * Parse a PDF document an return an array of objects.
@@ -177,7 +178,8 @@ class tcpdi_parser {
      * @public
      * @since 1.0.000 (2011-05-24)
      */
-    public function __construct($data, $uniqueid) {
+    public function __construct($data, $uniqueid)
+    {
         if (empty($data)) {
             $this->Error('Empty PDF data.');
         }
@@ -205,7 +207,8 @@ class tcpdi_parser {
     /**
      * Clean up when done, to free memory etc
      */
-    public function cleanUp() {
+    public function cleanUp()
+    {
         unset($this->pdfdata);
         $this->pdfdata = '';
         unset($this->objstreams);
@@ -228,7 +231,8 @@ class tcpdi_parser {
      * @public
      * @since 1.0.000 (2011-06-26)
      */
-    public function getParsedData() {
+    public function getParsedData()
+    {
         return array($this->xref, $this->objects, $this->pages);
     }
 
@@ -238,7 +242,8 @@ class tcpdi_parser {
      * And reset the PDF Version used in FPDI if needed
      * @public
      */
-    public function getPDFVersion() {
+    public function getPDFVersion()
+    {
         preg_match('/\d\.\d/', substr($this->pdfdata, 0, 16), $m);
         if (isset($m[0]))
             $this->pdfVersion = $m[0];
@@ -249,10 +254,11 @@ class tcpdi_parser {
      * Read all /Page(es)
      *
      */
-    function readPages() {
+    function readPages()
+    {
         $params = $this->getObjectVal($this->xref['trailer'][1]['/Root']);
         $objref = null;
-        foreach ($params[1][1] as $k=>$v) {
+        foreach ($params[1][1] as $k => $v) {
             if ($k == '/Pages') {
                 $objref = $v;
                 break;
@@ -291,7 +297,8 @@ class tcpdi_parser {
      * Read a single /Page element, recursing through /Kids if necessary
      *
      */
-    private function readPage($page) {
+    private function readPage($page)
+    {
         if (isset($page[1][1]['/Kids'])) {
             // Nested pages!
             foreach ($page[1][1]['/Kids'][1] as $subref) {
@@ -308,7 +315,8 @@ class tcpdi_parser {
      *
      * @return int
      */
-    function getPageCount() {
+    function getPageCount()
+    {
         return $this->page_count;
     }
 
@@ -320,7 +328,8 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.000 (2011-05-24)
      */
-    protected function getXrefData($offset=0, $xref=array()) {
+    protected function getXrefData($offset = 0, $xref = array())
+    {
         if ($offset == 0) {
             // find last startxref
             if (preg_match('/.*[\r\n]startxref[\s\r\n]+([0-9]+)[\s\r\n]+%%EOF/is', $this->pdfdata, $matches) == 0) {
@@ -351,7 +360,7 @@ class tcpdi_parser {
             try {
                 // Cross-Reference Stream
                 $xref = $this->decodeXrefStream($startxref, $xref);
-            } catch (\Exception $e){
+            } catch (\Exception $e) {
                 $xref = $this->decodeXref($startxref, $xref);
             }
         }
@@ -370,7 +379,8 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.000 (2011-06-20)
      */
-    protected function decodeXref($startxref, $xref=array()) {
+    protected function decodeXref($startxref, $xref = array())
+    {
         $this->xref_seen_offsets[] = $startxref;
         if (!isset($xref['xref_location'])) {
             $xref['xref_location'] = $startxref;
@@ -386,7 +396,7 @@ class tcpdi_parser {
             if ($matches[3][0] == 'n') {
                 // create unique object index: [object number]_[generation number]
                 $gen_num = intval($matches[2][0]);
-                $index = $obj_num.'_'.$gen_num;
+                $index = $obj_num . '_' . $gen_num;
                 // check if object already exist
                 if (!isset($xref['xref'][$obj_num][$gen_num])) {
                     // store object offset position
@@ -407,7 +417,7 @@ class tcpdi_parser {
         // get trailer data
         if (preg_match('/trailer[\s]*<<(.*)>>[\s\r\n]+(?:[%].*[\r\n]+)*startxref[\s\r\n]+/isU', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE, $xoffset) > 0) {
             $trailer_data = $matches[1][0];
-            if (!isset($xref['trailer']) OR empty($xref['trailer'])) {
+            if (!isset($xref['trailer']) or empty($xref['trailer'])) {
                 // get only the last updated version
                 $xref['trailer'] = array();
                 $xref['trailer'][0] = PDF_TYPE_DICTIONARY;
@@ -454,7 +464,8 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.003 (2013-03-16)
      */
-    protected function decodeXrefStream($startxref, $xref=array()) {
+    protected function decodeXrefStream($startxref, $xref = array())
+    {
         // try to read Cross-Reference Stream
         list($xrefobj, $unused) = $this->getRawObject($startxref);
         $xrefcrs = $this->getIndirectObject($xrefobj[1], $startxref, true);
@@ -465,7 +476,7 @@ class tcpdi_parser {
         if (!isset($xref['xref'])) {
             $xref['xref'] = array();
         }
-        if (!isset($xref['trailer']) OR empty($xref['trailer'])) {
+        if (!isset($xref['trailer']) or empty($xref['trailer'])) {
             // get only the last updated version
             $xref['trailer'] = array();
             $xref['trailer'][0] = PDF_TYPE_DICTIONARY;
@@ -479,35 +490,35 @@ class tcpdi_parser {
         $keys = array_keys($sarr);
         $columns = 1; // Default as per PDF 32000-1:2008.
         $predictor = 1; // Default as per PDF 32000-1:2008.
-        foreach ($keys as $k=>$key) {
+        foreach ($keys as $k => $key) {
             $v = $sarr[$key];
-            if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
+            if (($key == '/Type') and ($v[0] == PDF_TYPE_TOKEN and ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1]) >= 2)) {
+            } elseif (($key == '/Index') and ($v[0] == PDF_TYPE_ARRAY and count($v[1]) >= 2)) {
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection
                 $index_entries = intval($v[1][1][1]);
-            } elseif (($key == '/Prev') AND ($v[0] == PDF_TYPE_NUMERIC)) {
+            } elseif (($key == '/Prev') and ($v[0] == PDF_TYPE_NUMERIC)) {
                 // get previous xref offset
                 $prevxref = intval($v[1]);
-            } elseif (($key == '/W') AND ($v[0] == PDF_TYPE_ARRAY)) {
+            } elseif (($key == '/W') and ($v[0] == PDF_TYPE_ARRAY)) {
                 // number of bytes (in the decoded stream) of the corresponding field
                 $wb = array();
                 $wb[0] = intval($v[1][0][1]);
                 $wb[1] = intval($v[1][1][1]);
                 $wb[2] = intval($v[1][2][1]);
-            } elseif (($key == '/DecodeParms') AND ($v[0] == PDF_TYPE_DICTIONARY)) {
+            } elseif (($key == '/DecodeParms') and ($v[0] == PDF_TYPE_DICTIONARY)) {
                 $decpar = $v[1];
                 foreach ($decpar as $kdc => $vdc) {
-                    if (($kdc == '/Columns') AND ($vdc[0] == PDF_TYPE_NUMERIC)) {
+                    if (($kdc == '/Columns') and ($vdc[0] == PDF_TYPE_NUMERIC)) {
                         $columns = intval($vdc[1]);
-                    } elseif (($kdc == '/Predictor') AND ($vdc[0] == PDF_TYPE_NUMERIC)) {
+                    } elseif (($kdc == '/Predictor') and ($vdc[0] == PDF_TYPE_NUMERIC)) {
                         $predictor = intval($vdc[1]);
                     }
                 }
             } elseif ($filltrailer) {
-                switch($key) {
+                switch ($key) {
                     case '/Size':
                     case '/Root':
                     case '/Info':
@@ -521,7 +532,7 @@ class tcpdi_parser {
         }
         // decode data
         $obj_num = 0;
-        if ($valid_crs AND isset($xrefcrs[1][3][0])) {
+        if ($valid_crs and isset($xrefcrs[1][3][0])) {
             // number of bytes in a row
             $rowlen = ($columns + 1);
             // convert the stream into an array of integers
@@ -531,7 +542,7 @@ class tcpdi_parser {
             // initialize decoded array
             $ddata = array();
             // initialize first row with zeros
-            $prev_row = array_fill (0, $rowlen, 0);
+            $prev_row = array_fill(0, $rowlen, 0);
             // for each row apply PNG unpredictor
             foreach ($sdata as $k => $row) {
                 // initialize new row
@@ -541,7 +552,7 @@ class tcpdi_parser {
                     $predictor = (10 + $row[0]);
                 }
                 // for each byte on the row
-                for ($i=1; $i<=$columns; ++$i) {
+                for ($i = 1; $i <= $columns; ++$i) {
                     if (!isset($row[$i])) {
                         // No more data in this row - we're done here.
                         break;
@@ -559,50 +570,50 @@ class tcpdi_parser {
                     switch ($predictor) {
                         case 1: // No prediction (equivalent to PNG None)
                         case 10: { // PNG prediction (on encoding, PNG None on all rows)
-                            $ddata[$k][$j] = $row[$i];
-                            break;
-                        }
-                        case 11: { // PNG prediction (on encoding, PNG Sub on all rows)
-                            $ddata[$k][$j] = (($row[$i] + $row_left) & 0xff);
-                            break;
-                        }
-                        case 12: { // PNG prediction (on encoding, PNG Up on all rows)
-                            $ddata[$k][$j] = (($row[$i] + $row_up) & 0xff);
-                            break;
-                        }
-                        case 13: { // PNG prediction (on encoding, PNG Average on all rows)
-                            $ddata[$k][$j] = (($row[$i] + (($row_left + $row_up) / 2)) & 0xff);
-                            break;
-                        }
-                        case 14: { // PNG prediction (on encoding, PNG Paeth on all rows)
-                            // initial estimate
-                            $p = ($row_left + $row_up - $row_upleft);
-                            // distances
-                            $pa = abs($p - $row_left);
-                            $pb = abs($p - $row_up);
-                            $pc = abs($p - $row_upleft);
-                            $pmin = min($pa, $pb, $pc);
-                            // return minumum distance
-                            switch ($pmin) {
-                                case $pa: {
-                                    $ddata[$k][$j] = (($row[$i] + $row_left) & 0xff);
-                                    break;
-                                }
-                                case $pb: {
-                                    $ddata[$k][$j] = (($row[$i] + $row_up) & 0xff);
-                                    break;
-                                }
-                                case $pc: {
-                                    $ddata[$k][$j] = (($row[$i] + $row_upleft) & 0xff);
-                                    break;
-                                }
+                                $ddata[$k][$j] = $row[$i];
+                                break;
                             }
-                            break;
-                        }
+                        case 11: { // PNG prediction (on encoding, PNG Sub on all rows)
+                                $ddata[$k][$j] = (($row[$i] + $row_left) & 0xff);
+                                break;
+                            }
+                        case 12: { // PNG prediction (on encoding, PNG Up on all rows)
+                                $ddata[$k][$j] = (($row[$i] + $row_up) & 0xff);
+                                break;
+                            }
+                        case 13: { // PNG prediction (on encoding, PNG Average on all rows)
+                                $ddata[$k][$j] = (($row[$i] + (($row_left + $row_up) / 2)) & 0xff);
+                                break;
+                            }
+                        case 14: { // PNG prediction (on encoding, PNG Paeth on all rows)
+                                // initial estimate
+                                $p = ($row_left + $row_up - $row_upleft);
+                                // distances
+                                $pa = abs($p - $row_left);
+                                $pb = abs($p - $row_up);
+                                $pc = abs($p - $row_upleft);
+                                $pmin = min($pa, $pb, $pc);
+                                // return minumum distance
+                                switch ($pmin) {
+                                    case $pa: {
+                                            $ddata[$k][$j] = (($row[$i] + $row_left) & 0xff);
+                                            break;
+                                        }
+                                    case $pb: {
+                                            $ddata[$k][$j] = (($row[$i] + $row_up) & 0xff);
+                                            break;
+                                        }
+                                    case $pc: {
+                                            $ddata[$k][$j] = (($row[$i] + $row_upleft) & 0xff);
+                                            break;
+                                        }
+                                }
+                                break;
+                            }
                         default: { // PNG prediction (on encoding, PNG optimum)
-                            $this->Error("Unknown PNG predictor $predictor");
-                            break;
-                        }
+                                $this->Error("Unknown PNG predictor $predictor");
+                                break;
+                            }
                     }
                 }
                 $prev_row = $ddata[$k];
@@ -640,30 +651,30 @@ class tcpdi_parser {
             foreach ($sdata as $k => $row) {
                 switch ($row[0]) {
                     case 0: { // (f) linked list of free objects
-                        ++$obj_num;
-                        break;
-                    }
-                    case 1: { // (n) objects that are in use but are not compressed
-                        // create unique object index: [object number]_[generation number]
-                        $index = $obj_num.'_'.$row[2];
-                        // check if object already exist
-                        if (!isset($xref['xref'][$obj_num][$row[2]])) {
-                            // store object offset position
-                            $xref['xref'][$obj_num][$row[2]] = $row[1];
+                            ++$obj_num;
+                            break;
                         }
-                        ++$obj_num;
-                        break;
-                    }
+                    case 1: { // (n) objects that are in use but are not compressed
+                            // create unique object index: [object number]_[generation number]
+                            $index = $obj_num . '_' . $row[2];
+                            // check if object already exist
+                            if (!isset($xref['xref'][$obj_num][$row[2]])) {
+                                // store object offset position
+                                $xref['xref'][$obj_num][$row[2]] = $row[1];
+                            }
+                            ++$obj_num;
+                            break;
+                        }
                     case 2: { // compressed objects
-                        // $row[1] = object number of the object stream in which this object is stored
-                        // $row[2] = index of this object within the object stream
-                        /*$index = $row[1].'_0_'.$row[2];
+                            // $row[1] = object number of the object stream in which this object is stored
+                            // $row[2] = index of this object within the object stream
+                            /*$index = $row[1].'_0_'.$row[2];
                         $xref['xref'][$row[1]][0][$row[2]] = -1;*/
-                        break;
-                    }
+                            break;
+                        }
                     default: { // null objects
-                        break;
-                    }
+                            break;
+                        }
                 }
             }
         } // end decoding data
@@ -682,7 +693,8 @@ class tcpdi_parser {
      * @return string Steam content
      * @protected
      */
-    protected function getRawStream($offset, $length) {
+    protected function getRawStream($offset, $length)
+    {
         $offset += strspn($this->pdfdata, "\x00\x09\x0a\x0c\x0d\x20", $offset);
         $offset += 6; // "stream"
         $offset += strspn($this->pdfdata, "\x20", $offset);
@@ -692,7 +704,7 @@ class tcpdi_parser {
         $obj[] = PDF_TYPE_STREAM;
         $obj[] = substr($this->pdfdata, $offset, $length);
 
-        return array($obj, $offset+$length);
+        return array($obj, $offset + $length);
     }
 
     /**
@@ -702,9 +714,10 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.000 (2011-06-20)
      */
-    protected function getRawObject($offset=0, $data=null) {
+    protected function getRawObject($offset = 0, $data = null)
+    {
         if ($data == null) {
-            $data =& $this->pdfdata;
+            $data = &$this->pdfdata;
         }
         $objtype = ''; // object type to be returned
         $objval = ''; // object value to be returned
@@ -717,161 +730,161 @@ class tcpdi_parser {
         // get object type
         switch ($char) {
             case '%': { // \x25 PERCENT SIGN
-                // skip comment and search for next token
-                $next = strcspn($data, "\r\n", $offset);
-                if ($next > 0) {
-                    $offset += $next;
-                    list($obj, $unused) = $this->getRawObject($offset, $data);
-                    return $obj;
+                    // skip comment and search for next token
+                    $next = strcspn($data, "\r\n", $offset);
+                    if ($next > 0) {
+                        $offset += $next;
+                        list($obj, $unused) = $this->getRawObject($offset, $data);
+                        return $obj;
+                    }
+                    break;
                 }
-                break;
-            }
             case '/': { // \x2F SOLIDUS
-                // name object
-                $objtype = PDF_TYPE_TOKEN;
-                ++$offset;
-                $length = strcspn($data, "\x00\x09\x0a\x0c\x0d\x20\x28\x29\x3c\x3e\x5b\x5d\x7b\x7d\x2f\x25", $offset);
-                $objval = substr($data, $offset, $length);
-                $offset += $length;
-                break;
-            }
+                    // name object
+                    $objtype = PDF_TYPE_TOKEN;
+                    ++$offset;
+                    $length = strcspn($data, "\x00\x09\x0a\x0c\x0d\x20\x28\x29\x3c\x3e\x5b\x5d\x7b\x7d\x2f\x25", $offset);
+                    $objval = substr($data, $offset, $length);
+                    $offset += $length;
+                    break;
+                }
             case '(':   // \x28 LEFT PARENTHESIS
             case ')': { // \x29 RIGHT PARENTHESIS
-                // literal string object
-                $objtype = PDF_TYPE_STRING;
-                ++$offset;
-                $strpos = $offset;
-                if ($char == '(') {
-                    $open_bracket = 1;
-                    while ($open_bracket > 0) {
-                        if (!isset($data[$strpos])) {
-                            break;
+                    // literal string object
+                    $objtype = PDF_TYPE_STRING;
+                    ++$offset;
+                    $strpos = $offset;
+                    if ($char == '(') {
+                        $open_bracket = 1;
+                        while ($open_bracket > 0) {
+                            if (!isset($data[$strpos])) {
+                                break;
+                            }
+                            $ch = $data[$strpos];
+                            switch ($ch) {
+                                case '\\': { // REVERSE SOLIDUS (5Ch) (Backslash)
+                                        // skip next character
+                                        ++$strpos;
+                                        break;
+                                    }
+                                case '(': { // LEFT PARENHESIS (28h)
+                                        ++$open_bracket;
+                                        break;
+                                    }
+                                case ')': { // RIGHT PARENTHESIS (29h)
+                                        --$open_bracket;
+                                        break;
+                                    }
+                            }
+                            ++$strpos;
                         }
-                        $ch = $data[$strpos];
-                        switch ($ch) {
-                            case '\\': { // REVERSE SOLIDUS (5Ch) (Backslash)
-                                // skip next character
-                                ++$strpos;
-                                break;
-                            }
-                            case '(': { // LEFT PARENHESIS (28h)
-                                ++$open_bracket;
-                                break;
-                            }
-                            case ')': { // RIGHT PARENTHESIS (29h)
-                                --$open_bracket;
-                                break;
-                            }
-                        }
-                        ++$strpos;
+                        $objval = substr($data, $offset, ($strpos - $offset - 1));
+                        $offset = $strpos;
                     }
-                    $objval = substr($data, $offset, ($strpos - $offset - 1));
-                    $offset = $strpos;
+                    break;
                 }
-                break;
-            }
             case '[':   // \x5B LEFT SQUARE BRACKET
             case ']': { // \x5D RIGHT SQUARE BRACKET
-                // array object
-                $objtype = PDF_TYPE_ARRAY;
-                ++$offset;
-                if ($char == '[') {
-                    // get array content
-                    $objval = array();
-                    do {
-                        // get element
-                        list($element, $offset) = $this->getRawObject($offset, $data);
-                        $objval[] = $element;
-                    } while ($element[0] !== ']');
-                    // remove closing delimiter
-                    array_pop($objval);
-                } else {
-                    $objtype = ']';
+                    // array object
+                    $objtype = PDF_TYPE_ARRAY;
+                    ++$offset;
+                    if ($char == '[') {
+                        // get array content
+                        $objval = array();
+                        do {
+                            // get element
+                            list($element, $offset) = $this->getRawObject($offset, $data);
+                            $objval[] = $element;
+                        } while ($element[0] !== ']');
+                        // remove closing delimiter
+                        array_pop($objval);
+                    } else {
+                        $objtype = ']';
+                    }
+                    break;
                 }
-                break;
-            }
             case '<':   // \x3C LESS-THAN SIGN
             case '>': { // \x3E GREATER-THAN SIGN
-                if (isset($data[($offset + 1)]) AND ($data[($offset + 1)] == $char)) {
-                    // dictionary object
-                    $objtype = PDF_TYPE_DICTIONARY;
-                    if ($char == '<') {
-                        list ($objval, $offset) = $this->getDictValue($offset, $data);
-                    } else {
-                        $objtype = '>>';
-                        $offset += 2;
-                    }
-                } else {
-                    // hexadecimal string object
-                    $objtype = PDF_TYPE_HEX;
-                    ++$offset;
-                    // The "Panose" entry in the FontDescriptor Style dict seems to have hex bytes separated by spaces.
-                    if (($char == '<') AND (preg_match('/^([0-9A-Fa-f ]+)[>]/iU', substr($data, $offset), $matches) == 1)) {
-                        $objval = $matches[1];
-                        $offset += strlen($matches[0]);
-                        unset($matches);
-                    }
-                }
-                break;
-            }
-            default: {
-                $frag = $data[$offset] . @$data[$offset+1] . @$data[$offset+2] . @$data[$offset+3];
-                switch ($frag) {
-                    case 'endo':
-                        // indirect object
-                        $objtype = 'endobj';
-                        $offset += 6;
-                        break;
-                    case 'stre':
-                        // Streams should always be indirect objects, and thus processed by getRawStream().
-                        // If we get here, treat it as a null object as something has gone wrong.
-                    case 'null':
-                        // null object
-                        $objtype = PDF_TYPE_NULL;
-                        $offset += 4;
-                        $objval = 'null';
-                        break;
-                    case 'true':
-                        // boolean true object
-                        $objtype = PDF_TYPE_BOOLEAN;
-                        $offset += 4;
-                        $objval = true;
-                        break;
-                    case 'fals':
-                        // boolean false object
-                        $objtype = PDF_TYPE_BOOLEAN;
-                        $offset += 5;
-                        $objval = false;
-                        break;
-                    case 'ends':
-                        // end stream object
-                        $objtype = 'endstream';
-                        $offset += 9;
-                        break;
-                    default:
-                        if (preg_match('/^([0-9]+)[\s]+([0-9]+)[\s]+([Robj]{1,3})/i', substr($data, $offset, 33), $matches) == 1) {
-                            if ($matches[3] == 'R') {
-                                // indirect object reference
-                                $objtype = PDF_TYPE_OBJREF;
-                                $offset += strlen($matches[0]);
-                                $objval = array(intval($matches[1]), intval($matches[2]));
-                            } elseif ($matches[3] == 'obj') {
-                                // object start
-                                $objtype = PDF_TYPE_OBJECT;
-                                $objval = intval($matches[1]).'_'.intval($matches[2]);
-                                $offset += strlen ($matches[0]);
-                            }
-                        } elseif (($numlen = strspn($data, '+-.0123456789', $offset)) > 0) {
-                            // numeric object
-                            $objval = substr($data, $offset, $numlen);
-                            $objtype = (intval($objval) != $objval) ? PDF_TYPE_REAL : PDF_TYPE_NUMERIC;
-                            $offset += $numlen;
+                    if (isset($data[($offset + 1)]) and ($data[($offset + 1)] == $char)) {
+                        // dictionary object
+                        $objtype = PDF_TYPE_DICTIONARY;
+                        if ($char == '<') {
+                            list($objval, $offset) = $this->getDictValue($offset, $data);
+                        } else {
+                            $objtype = '>>';
+                            $offset += 2;
                         }
-                        unset($matches);
-                        break;
+                    } else {
+                        // hexadecimal string object
+                        $objtype = PDF_TYPE_HEX;
+                        ++$offset;
+                        // The "Panose" entry in the FontDescriptor Style dict seems to have hex bytes separated by spaces.
+                        if (($char == '<') and (preg_match('/^([0-9A-Fa-f ]+)[>]/iU', substr($data, $offset), $matches) == 1)) {
+                            $objval = $matches[1];
+                            $offset += strlen($matches[0]);
+                            unset($matches);
+                        }
+                    }
+                    break;
                 }
-                break;
-            }
+            default: {
+                    $frag = $data[$offset] . @$data[$offset + 1] . @$data[$offset + 2] . @$data[$offset + 3];
+                    switch ($frag) {
+                        case 'endo':
+                            // indirect object
+                            $objtype = 'endobj';
+                            $offset += 6;
+                            break;
+                        case 'stre':
+                            // Streams should always be indirect objects, and thus processed by getRawStream().
+                            // If we get here, treat it as a null object as something has gone wrong.
+                        case 'null':
+                            // null object
+                            $objtype = PDF_TYPE_NULL;
+                            $offset += 4;
+                            $objval = 'null';
+                            break;
+                        case 'true':
+                            // boolean true object
+                            $objtype = PDF_TYPE_BOOLEAN;
+                            $offset += 4;
+                            $objval = true;
+                            break;
+                        case 'fals':
+                            // boolean false object
+                            $objtype = PDF_TYPE_BOOLEAN;
+                            $offset += 5;
+                            $objval = false;
+                            break;
+                        case 'ends':
+                            // end stream object
+                            $objtype = 'endstream';
+                            $offset += 9;
+                            break;
+                        default:
+                            if (preg_match('/^([0-9]+)[\s]+([0-9]+)[\s]+([Robj]{1,3})/i', substr($data, $offset, 33), $matches) == 1) {
+                                if ($matches[3] == 'R') {
+                                    // indirect object reference
+                                    $objtype = PDF_TYPE_OBJREF;
+                                    $offset += strlen($matches[0]);
+                                    $objval = array(intval($matches[1]), intval($matches[2]));
+                                } elseif ($matches[3] == 'obj') {
+                                    // object start
+                                    $objtype = PDF_TYPE_OBJECT;
+                                    $objval = intval($matches[1]) . '_' . intval($matches[2]);
+                                    $offset += strlen($matches[0]);
+                                }
+                            } elseif (($numlen = strspn($data, '+-.0123456789', $offset)) > 0) {
+                                // numeric object
+                                $objval = substr($data, $offset, $numlen);
+                                $objtype = (intval($objval) != $objval) ? PDF_TYPE_REAL : PDF_TYPE_NUMERIC;
+                                $offset += $numlen;
+                            }
+                            unset($matches);
+                            break;
+                    }
+                    break;
+                }
         }
         $obj = array();
         $obj[] = $objtype;
@@ -884,19 +897,20 @@ class tcpdi_parser {
         }
         return array($obj, $offset);
     }
-    private function getDictValue($offset, &$data) {
+    private function getDictValue($offset, &$data)
+    {
         $objval = array();
 
         // Extract dict from data.
-        $i=1;
+        $i = 1;
         $dict = '';
         $offset += 2;
         do {
-            if ($data[$offset] == '>' && $data[$offset+1] == '>') {
+            if ($data[$offset] == '>' && $data[$offset + 1] == '>') {
                 $i--;
                 $dict .= '>>';
                 $offset += 2;
-            } else if ($data[$offset] == '<' && $data[$offset+1] == '<') {
+            } else if ($data[$offset] == '<' && $data[$offset + 1] == '<') {
                 $i++;
                 $dict .= '<<';
                 $offset += 2;
@@ -904,7 +918,7 @@ class tcpdi_parser {
                 $dict .= $data[$offset];
                 $offset++;
             }
-        } while ($i>0);
+        } while ($i > 0);
 
         // Now that we have just the dict, parse it.
         $dictoffset = 0;
@@ -915,7 +929,7 @@ class tcpdi_parser {
                 break;
             }
             list($element, $dictoffset) = $this->getRawObject($eloffset, $dict);
-            $objval['/'.$key[1]] = $element;
+            $objval['/' . $key[1]] = $element;
             unset($key);
             unset($element);
         } while (true);
@@ -932,13 +946,14 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.000 (2011-05-24)
      */
-    protected function getIndirectObject($obj_ref, $offset=0, $decoding=true) {
+    protected function getIndirectObject($obj_ref, $offset = 0, $decoding = true)
+    {
         $obj = explode('_', $obj_ref);
-        if (($obj === false) OR (count($obj) != 2)) {
+        if (($obj === false) or (count($obj) != 2)) {
             $this->Error('Invalid object reference: ' . json_encode($obj));
             return;
         }
-        $objref = $obj[0].' '.$obj[1].' obj';
+        $objref = $obj[0] . ' ' . $obj[1] . ' obj';
 
         if (strpos($this->pdfdata, $objref, $offset) != $offset) {
             // an indirect reference to an undefined object shall be considered a reference to the null object
@@ -950,9 +965,9 @@ class tcpdi_parser {
         $objdata = array();
         $i = 0; // object main index
         do {
-            if (($i > 0) AND (isset($objdata[($i - 1)][0])) AND ($objdata[($i - 1)][0] == PDF_TYPE_DICTIONARY) AND array_key_exists('/Length', $objdata[($i - 1)][1])) {
+            if (($i > 0) and (isset($objdata[($i - 1)][0])) and ($objdata[($i - 1)][0] == PDF_TYPE_DICTIONARY) and array_key_exists('/Length', $objdata[($i - 1)][1])) {
                 // Stream - get using /Length in stream's dict
-                $lengthobj = $objdata[($i-1)][1]['/Length'];
+                $lengthobj = $objdata[($i - 1)][1]['/Length'];
                 if ($lengthobj[0] === PDF_TYPE_OBJREF) {
                     $lengthobj = $this->getObjectVal($lengthobj);
                     if ($lengthobj[0] === PDF_TYPE_OBJECT) {
@@ -966,7 +981,7 @@ class tcpdi_parser {
                 list($element, $offset) = $this->getRawObject($offset);
             }
             // decode stream using stream's dictionary information
-            if ($decoding AND ($element[0] == PDF_TYPE_STREAM) AND (isset($objdata[($i - 1)][0])) AND ($objdata[($i - 1)][0] == PDF_TYPE_DICTIONARY)) {
+            if ($decoding and ($element[0] == PDF_TYPE_STREAM) and (isset($objdata[($i - 1)][0])) and ($objdata[($i - 1)][0] == PDF_TYPE_DICTIONARY)) {
                 $element[3] = $this->decodeStream($objdata[($i - 1)][1], $element[1]);
             }
             $objdata[$i] = $element;
@@ -985,7 +1000,8 @@ class tcpdi_parser {
      * @public
      * @since 1.0.000 (2011-06-26)
      */
-    public function getObjectVal($obj) {
+    public function getObjectVal($obj)
+    {
         if ($obj[0] == PDF_TYPE_OBJREF) {
             if (strpos($obj[1], '_') !== false) {
                 $key = explode('_', $obj[1]);
@@ -993,7 +1009,7 @@ class tcpdi_parser {
                 $key = array($obj[1], $obj[2]);
             }
 
-            $ret = array(0=>PDF_TYPE_OBJECT, 'obj'=>$key[0], 'gen'=>$key[1]);
+            $ret = array(0 => PDF_TYPE_OBJECT, 'obj' => $key[0], 'gen' => $key[1]);
 
             // reference to indirect object
             $object = null;
@@ -1002,7 +1018,7 @@ class tcpdi_parser {
                 $object = $this->objects[$key[0]][$key[1]];
             } elseif (($offset = $this->findObjectOffset($key)) !== false) {
                 // parse new object
-                $this->objects[$key[0]][$key[1]] = $this->getIndirectObject($key[0].'_'.$key[1], $offset, false);
+                $this->objects[$key[0]][$key[1]] = $this->getIndirectObject($key[0] . '_' . $key[1], $offset, false);
                 $object = $this->objects[$key[0]][$key[1]];
             } elseif (($key[1] == 0) && isset($this->objstreamobjs[$key[0]])) {
                 // Object is in an object stream
@@ -1037,19 +1053,20 @@ class tcpdi_parser {
      * Extract object stream to find out what it contains.
      *
      */
-    function extractObjectStream($key) {
+    function extractObjectStream($key)
+    {
         $objref = array(PDF_TYPE_OBJREF, $key[0], $key[1]);
         $obj = $this->getObjectVal($objref);
         if ($obj[0] !== PDF_TYPE_STREAM || !isset($obj[1][1]['/First'][1])) {
             // Not a valid object stream dictionary - skip it.
             return;
         }
-        $stream = $this->decodeStream($obj[1][1], $obj[2][1]);// Decode object stream, as we need the first bit
+        $stream = $this->decodeStream($obj[1][1], $obj[2][1]); // Decode object stream, as we need the first bit
         $first = intval($obj[1][1]['/First'][1]);
         $ints = preg_split('/\s/', substr($stream[0], 0, $first)); // Get list of object / offset pairs
-        for ($j=1; $j<count($ints); $j++) {
+        for ($j = 1; $j < count($ints); $j++) {
             if (($j % 2) == 1) {
-                $this->objstreamobjs[$ints[$j-1]] = array($key, $ints[$j]+$first);
+                $this->objstreamobjs[$ints[$j - 1]] = array($key, $ints[$j] + $first);
             }
         }
 
@@ -1062,12 +1079,13 @@ class tcpdi_parser {
      * Find all object offsets.  Saves having to scour the file multiple times.
      * @private
      */
-    private function findObjectOffsets() {
+    private function findObjectOffsets()
+    {
         $this->objoffsets = array();
         if (preg_match_all('/(*ANYCRLF)^[\s]*([0-9]+)[\s]+([0-9]+)[\s]+obj/im', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE) >= 1) {
             $i = 0;
             $laststreamend = 0;
-            foreach($matches[0] as $match) {
+            foreach ($matches[0] as $match) {
                 $offset = $match[1] + strspn($match[0], "\x00\x09\x0a\x0c\x0d\x20");
                 if ($offset < $laststreamend) {
                     // Contained within another stream, skip it.
@@ -1096,8 +1114,9 @@ class tcpdi_parser {
      * @return int Offset of the object in $this->pdfdata.
      * @private
      */
-    private function findObjectOffset($key) {
-        $objref = $key[0].' '.$key[1].' obj';
+    private function findObjectOffset($key)
+    {
+        $objref = $key[0] . ' ' . $key[1] . ' obj';
         if (isset($this->xref['xref'][$key[0]][$key[1]])) {
             $offset = $this->xref['xref'][$key[0]][$key[1]];
             if (strpos($this->pdfdata, $objref, $offset) === $offset) {
@@ -1121,7 +1140,8 @@ class tcpdi_parser {
      * @protected
      * @since 1.0.000 (2011-06-22)
      */
-    protected function decodeStream($sdic, $stream) {
+    protected function decodeStream($sdic, $stream)
+    {
         // get stream lenght and filters
         $slength = strlen($stream);
         if ($slength <= 0) {
@@ -1130,7 +1150,7 @@ class tcpdi_parser {
         $filters = array();
         foreach ($sdic as $k => $v) {
             if ($v[0] == PDF_TYPE_TOKEN) {
-                if (($k == '/Length') AND ($v[0] == PDF_TYPE_NUMERIC)) {
+                if (($k == '/Length') and ($v[0] == PDF_TYPE_NUMERIC)) {
                     // get declared stream lenght
                     $declength = intval($v[1]);
                     if ($declength < $slength) {
@@ -1171,11 +1191,12 @@ class tcpdi_parser {
      *
      * @param int $pageno Pagenumber to use
      */
-    public function setPageno($pageno) {
+    public function setPageno($pageno)
+    {
         $pageno = ((int) $pageno) - 1;
 
         if ($pageno < 0 || $pageno >= $this->getPageCount()) {
-            $this->error("Pagenumber is wrong! (Requested $pageno, max ".$this->getPageCount().")");
+            $this->error("Pagenumber is wrong! (Requested $pageno, max " . $this->getPageCount() . ")");
         }
 
         $this->pageno = $pageno;
@@ -1186,7 +1207,8 @@ class tcpdi_parser {
      *
      * @return array
      */
-    public function getPageResources() {
+    public function getPageResources()
+    {
         return $this->_getPageResources($this->pages[$this->pageno]);
     }
 
@@ -1195,20 +1217,21 @@ class tcpdi_parser {
      *
      * @param array $obj Array of pdf-data
      */
-    private function _getPageResources ($obj) { // $obj = /Page
+    private function _getPageResources($obj)
+    { // $obj = /Page
         $obj = $this->getObjectVal($obj);
 
         // If the current object has a resources
         // dictionary associated with it, we use
         // it. Otherwise, we move back to its
         // parent object.
-        if (isset ($obj[1][1]['/Resources'])) {
+        if (isset($obj[1][1]['/Resources'])) {
             $res = $obj[1][1]['/Resources'];
             if ($res[0] == PDF_TYPE_OBJECT)
                 return $res[1];
             return $res;
         } else {
-            if (!isset ($obj[1][1]['/Parent'])) {
+            if (!isset($obj[1][1]['/Parent'])) {
                 return false;
             } else {
                 $res = $this->_getPageResources($obj[1][1]['/Parent']);
@@ -1224,7 +1247,8 @@ class tcpdi_parser {
      *
      * @return array
      */
-    public function getPageAnnotations() {
+    public function getPageAnnotations()
+    {
         return $this->_getPageAnnotations($this->pages[$this->pageno]);
     }
 
@@ -1233,24 +1257,25 @@ class tcpdi_parser {
      *
      * @param array $obj Array of pdf-data
      */
-    private function _getPageAnnotations ($obj) { // $obj = /Page
+    private function _getPageAnnotations($obj)
+    { // $obj = /Page
         $obj = $this->getObjectVal($obj);
 
         // If the current object has an annotations
         // dictionary associated with it, we use
         // it. Otherwise, we move back to its
         // parent object.
-        if (isset ($obj[1][1]['/Annots'])) {
+        if (isset($obj[1][1]['/Annots'])) {
             $annots = $obj[1][1]['/Annots'];
         } else {
-            if (!isset ($obj[1][1]['/Parent'])) {
+            if (!isset($obj[1][1]['/Parent'])) {
                 return false;
             } else {
                 $annots = $this->_getPageAnnotations($obj[1][1]['/Parent']);
             }
         }
 
-        if ($annots[0] == PDF_TYPE_OBJREF)
+        if (($annots[0] ?? []) == PDF_TYPE_OBJREF)
             return $this->getObjectVal($annots);
         return $annots;
     }
@@ -1263,12 +1288,13 @@ class tcpdi_parser {
      *
      * @return string
      */
-    public function getContent() {
+    public function getContent()
+    {
         $buffer = '';
 
         if (isset($this->pages[$this->pageno][1][1]['/Contents'])) {
             $contents = $this->_getPageContent($this->pages[$this->pageno][1][1]['/Contents']);
-            foreach($contents AS $tmp_content) {
+            foreach ($contents as $tmp_content) {
                 $buffer .= $this->_rebuildContentStream($tmp_content) . ' ';
             }
         }
@@ -1283,7 +1309,8 @@ class tcpdi_parser {
      * @param array $content_ref
      * @return array
      */
-    private function _getPageContent($content_ref) {
+    private function _getPageContent($content_ref)
+    {
         $contents = array();
 
         if ($content_ref[0] == PDF_TYPE_OBJREF) {
@@ -1294,8 +1321,8 @@ class tcpdi_parser {
                 $contents[] = $content;
             }
         } elseif ($content_ref[0] == PDF_TYPE_ARRAY) {
-            foreach ($content_ref[1] AS $tmp_content_ref) {
-                $contents = array_merge($contents,$this->_getPageContent($tmp_content_ref));
+            foreach ($content_ref[1] as $tmp_content_ref) {
+                $contents = array_merge($contents, $this->_getPageContent($tmp_content_ref));
             }
         }
 
@@ -1309,7 +1336,8 @@ class tcpdi_parser {
      * @param array $obj
      * @return string
      */
-    private function _rebuildContentStream($obj) {
+    private function _rebuildContentStream($obj)
+    {
         $filters = array();
 
         if (isset($obj[1][1]['/Filter'])) {
@@ -1329,7 +1357,7 @@ class tcpdi_parser {
 
         $stream = $obj[2][1];
 
-        foreach ($filters AS $_filter) {
+        foreach ($filters as $_filter) {
             $stream = $this->FilterDecoders->decodeFilter($_filter[1], $stream);
         }
 
@@ -1346,11 +1374,12 @@ class tcpdi_parser {
      * @param float Scale factor from user space units to points
      * @return array
      */
-    public function getPageBox($page, $box_index, $k) {
+    public function getPageBox($page, $box_index, $k)
+    {
         $page = $this->getObjectVal($page);
         $box = null;
         if (isset($page[1][1][$box_index]))
-            $box =& $page[1][1][$box_index];
+            $box = &$page[1][1][$box_index];
 
         if (!is_null($box) && $box[0] == PDF_TYPE_OBJREF) {
             $tmp_box = $this->getObjectVal($box);
@@ -1358,17 +1387,18 @@ class tcpdi_parser {
         }
 
         if (!is_null($box) && $box[0] == PDF_TYPE_ARRAY) {
-            $b =& $box[1];
-            return array('x' => $b[0][1] / $k,
-                         'y' => $b[1][1] / $k,
-                         'w' => abs($b[0][1] - $b[2][1]) / $k,
-                         'h' => abs($b[1][1] - $b[3][1]) / $k,
-                         'llx' => min($b[0][1], $b[2][1]) / $k,
-                         'lly' => min($b[1][1], $b[3][1]) / $k,
-                         'urx' => max($b[0][1], $b[2][1]) / $k,
-                         'ury' => max($b[1][1], $b[3][1]) / $k,
-                         );
-        } elseif (!isset ($page[1][1]['/Parent'])) {
+            $b = &$box[1];
+            return array(
+                'x' => $b[0][1] / $k,
+                'y' => $b[1][1] / $k,
+                'w' => abs($b[0][1] - $b[2][1]) / $k,
+                'h' => abs($b[1][1] - $b[3][1]) / $k,
+                'llx' => min($b[0][1], $b[2][1]) / $k,
+                'lly' => min($b[1][1], $b[3][1]) / $k,
+                'urx' => max($b[0][1], $b[2][1]) / $k,
+                'ury' => max($b[1][1], $b[3][1]) / $k,
+            );
+        } elseif (!isset($page[1][1]['/Parent'])) {
             return false;
         } else {
             return $this->getPageBox($this->getObjectVal($page[1][1]['/Parent']), $box_index, $k);
@@ -1382,7 +1412,8 @@ class tcpdi_parser {
      * @param float Scale factor from user space units to points
      * @return array
      */
-    public function getPageBoxes($pageno, $k) {
+    public function getPageBoxes($pageno, $k)
+    {
         return $this->_getPageBoxes($this->pages[$pageno - 1], $k);
     }
 
@@ -1392,10 +1423,11 @@ class tcpdi_parser {
      * @param array a /Page
      * @return array
      */
-    private function _getPageBoxes($page, $k) {
+    private function _getPageBoxes($page, $k)
+    {
         $boxes = array();
 
-        foreach($this->availableBoxes AS $box) {
+        foreach ($this->availableBoxes as $box) {
             if ($_box = $this->getPageBox($page, $box, $k)) {
                 $boxes[$box] = $_box;
             }
@@ -1410,19 +1442,21 @@ class tcpdi_parser {
      * @param integer $pageno
      * @return array
      */
-    public function getPageRotation($pageno) {
+    public function getPageRotation($pageno)
+    {
         return $this->_getPageRotation($this->pages[$pageno - 1]);
     }
 
-    private function _getPageRotation($obj) { // $obj = /Page
+    private function _getPageRotation($obj)
+    { // $obj = /Page
         $obj = $this->getObjectVal($obj);
-        if (isset ($obj[1][1]['/Rotate'])) {
+        if (isset($obj[1][1]['/Rotate'])) {
             $res = $this->getObjectVal($obj[1][1]['/Rotate']);
             if ($res[0] == PDF_TYPE_OBJECT)
                 return $res[1];
             return $res;
         } else {
-            if (!isset ($obj[1][1]['/Parent'])) {
+            if (!isset($obj[1][1]['/Parent'])) {
                 return false;
             } else {
                 $res = $this->_getPageRotation($obj[1][1]['/Parent']);
@@ -1439,14 +1473,16 @@ class tcpdi_parser {
      * @public
      * @since 1.0.000 (2011-05-23)
      */
-    public function Error($msg) {
+    public function Error($msg)
+    {
         // exit program and print error
         throw new TcpdiParserException($msg);
     }
-
 } // END OF TCPDF_PARSER CLASS
 
-class TcpdiParserException extends Exception {}
+class TcpdiParserException extends Exception
+{
+}
 
 //============================================================+
 // END OF FILE


### PR DESCRIPTION
syntax fix -> https://github.com/kulbakin/tcpdi/compare/master...tgerakitis:tcpdi:master#diff-15c83608e45752ed700254bccaeec424a72089b3f577941dae86f59aac690fe5R286

fix in case `$annots` is bool which can happen if `$annots = $this->_getPageAnnotations($obj[1][1]['/Parent']);` retuns false
https://github.com/kulbakin/tcpdi/compare/master...tgerakitis:tcpdi:master#diff-fff033f744cda584f6332e87641d3e79b94162c63e8bb3b4eacfeec1c2b1810fR1278

rest is formatting