### PR TITLE
fix: illegal offsets

### DIFF
--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -815,7 +815,7 @@ class tcpdi_parser {
                 break;
             }
             default: {
-                $frag = $data[$offset] . @$data[$offset+1] . @$data[$offset+2] . @$data[$offset+3];
+                $frag = substr($data, $offset, 4);
                 switch ($frag) {
                     case 'endo':
                         // indirect object


### PR DESCRIPTION
In some cases $data[$offset] is out of range. It's throws E_WARNING error.